### PR TITLE
push comments onto array, ignore blank keys...

### DIFF
--- a/RequestTracker.php
+++ b/RequestTracker.php
@@ -326,7 +326,14 @@ class RequestTracker{
             $parts = explode($delimiter, $line);
             $key = array_shift($parts);
             $value = implode($delimiter, $parts);
-            $responseArray[$key] = trim($value);
+
+            // push comments to end of array, ignore blank keys
+            if($key !== ''){
+                if(strpos($key, '#')===0)
+                    $responseArray[] = $key;
+                else
+                    $responseArray[$key] = trim($value);
+            }
         }
 
         return $responseArray;


### PR DESCRIPTION
    * This is so working with/parsing comments won't require you to use array_keys to retrieve them first.
    * No point in having blank keys with blank values.