### PR TITLE
Update RequestTracker.php

### DIFF
--- a/RequestTracker.php
+++ b/RequestTracker.php
@@ -240,12 +240,17 @@ class RequestTracker{
      * @param int $attachmentId
      * @return array key=>value response pair array
      */
-    public function getAttachmentContent($ticketId, $attachmentId){
+    public function getAttachmentContent($ticketId, $attachmentId, $raw = false){
         $url = $this->url."ticket/$ticketId/attachments/$attachmentId/content";
         $this->setRequestUrl($url);
         
         $response = $this->send();
-        return $this->parseResponse($response);
+
+        if ( ! $raw ) {
+            return $this->parseResponse($response);
+        } else {
+            return $response;
+        }
     }
 
     /**


### PR DESCRIPTION
Hi Sam,
The change that I would like to propose, it is if would be possible to pass additional $raw param to getAttachmentContent() method to get the response without passing through parseResponse() method, because, for example to recover an image attachment, when it comes directly from Request Tracker REST API, I get raw something like this:
 <89>PNG^M
^Z
^@^@^@^MIHDR^@^@^H<98>^@

But when I recover from getAttachmentContent(), who pass it through parseResponse(), I get the same but into an array, with some parts in keys and other in value, something like this:
 Array
(
    [<89>PNG^M] =>
    [^Z] =>
    [^@^@^@^MIHDR^@^@^H<98>^@

Thus, in raw mode, the treatment could be managed in other way by the client, for example, returning it with Headers or in order to save the file in disk.
Thanks a lot to take a moment for read my proposition and thanks a lot for your good job.
Greetings