### PR TITLE
Remove closing php tags

### DIFF
--- a/RequestTracker.php
+++ b/RequestTracker.php
@@ -548,4 +548,3 @@ class RequestTracker{
 class RequestTrackerException extends Exception {}
 class AuthenticationException extends RequestTrackerException {}
 class HttpException extends RequestTrackerException {}
-?>


### PR DESCRIPTION
There is a newline after closing php tags which can create several problems with headers already sent etc. Lets just get rid of the closing tags completely 