### PR TITLE
Merge branch to add ticket attachments feature

### DIFF
--- a/RequestTracker.php
+++ b/RequestTracker.php
@@ -95,8 +95,17 @@ class RequestTracker{
      * content field for the POST.  If this is set to true, the postFields
      * will be used as the fields for the form instead of getting pushed
      * into the content field.
+     * 
+     * @param object[] $attachments Attachment's array to add to ticket
+     * 
+     * From original Request Tracker API, to add attachment to ticket while doing a comment
+     * we must add another attachment_1 param with raw file
+     * http://requesttracker.wikia.com/wiki/REST#Ticket_History_Comment
+     * After testings, one right way is to create CurlObject with file and to put into attachment_1
+     * because normal POST field fails
+     * More info: http://php.net/manual/en/class.curlfile.php
      */
-    protected function send($doNotUseContentField = false) {
+    protected function send($doNotUseContentField = false, $attachments = false) {
         if(!empty($this->postFields) && $doNotUseContentField == true) {
             $fields = $this->postFields;
             $fields['user'] = $this->user;
@@ -109,6 +118,12 @@ class RequestTracker{
             $fields = array('user'=>$this->user, 'pass'=>$this->pass);
         }
 
+        // If we've received attachment param, we have to add to POST params apart from 'content' and send Content-Type
+        if ( ! empty($attachments) ) {
+            foreach($attachments as $key => $attachment) {
+                $fields['attachment_'.$key] = $attachment;
+            }
+        }
         $response = $this->post($fields);
         $this->setPostFields('');
 
@@ -178,7 +193,28 @@ class RequestTracker{
 
         $this->setRequestUrl($url);
         $this->setPostFields($content);
-        $response = $this->send();
+
+        // If we have attachment_1 content, we have to pass it apart from inside 'content' array position
+        // and unset from postFields and from 'content' array because cannot convert CurlObject to String
+        // into parseArray() method inside send()
+        if ( ! empty($content['attachment_1'] ) ) {
+            
+            $attachContent = array();            
+            // search for all file fields            
+            $i = 1;
+            foreach($content as $key => $value){
+                if( strncmp($key, "attachment_", 11) == 0 ) {
+                    $attachContent[$i] = $value;
+                    unset($content['attachment_'.$i]);
+                    unset($this->postFields['attachment_'.$i]);
+                    $i++;
+                }
+            }
+            $response = $this->send(false, $attachContent);
+
+        } else {
+            $response = $this->send();
+        }
         return $this->parseResponse($response);
     }
 
@@ -276,6 +312,7 @@ class RequestTracker{
      * Get the content of an attachment
      * @param int $ticketId
      * @param int $attachmentId
+     * @param bool $raw
      * @return array key=>value response pair array
      */
     public function getAttachmentContent($ticketId, $attachmentId, $raw = false){
@@ -371,6 +408,7 @@ class RequestTracker{
     }
 
     private function parseResponse($response, $delimiter=':'){
+        $responseArray = array();
         $response = explode(chr(10), $response['body']);
         $response = $this->cleanResponseBody($response);
 


### PR DESCRIPTION
Following Request Tracker instructions to attach file to ticket:
http://requesttracker.wikia.com/wiki/REST#Ticket_History_Comment
we have to create an array structure like this:
id: 
Action: comment
Text: the text comment
Attachment: an attachment filename/path

If we want to attach file, we must fill Attachment field with info and then add another field called attachment_1 with the raw file content.

As far as I could see, I always got "RT/3.8.9 400 Bad Request # No attachment for..." error. I saw that send() method takes the original array to transform to the correct POST param called 'content' with all array fields in string form, separated with \n:
'content'=>$this->parseArray($this->postFields)
After some failed testing, I tried to send attachment_1 field apart from the rest, like user and pass fields do, like this:

$fields['user'] => $this->user,
$fields['pass'] => $this->pass,
$fields['content'] => $this->parseArray($this->postFields),
$fields['attachment_1'] = $attachment

in order to sent it without any raw file deformation, but always I continued getting 'Bad Request" error. Finally, reading more carefully theirs documentation:
"If you used "Attachment", you must add to your POST a variable "attachment_1" that contains the raw attachment in multi-part file object."
I tried another way using CurlObjects. This is to send it like this, but in attachment_1 field I put CurlFile, created like for example:
// Create a CURLFile object / procedural method 
$cfile = curl_file_create('resource/test.png','image/png','testpic');

This worked well for me, but to permit to send file POST data apart from 'content' field, I needed to modify doTicketComment() and Send() methods like I propose.

Thanks in advance