### PR TITLE
Implement __sleep method to avoid storing stateful info on serialize

### DIFF
--- a/RequestTracker.php
+++ b/RequestTracker.php
@@ -603,6 +603,15 @@ class RequestTracker
         $response =  array('code'=>$code, 'body'=>$response);
         return $response;
     }
+
+    /**
+     * Dont save any stateful information when serializing.
+     */
+    public function __sleep()
+    {
+        return array('url', 'user', 'pass', 'enableSslVerification');
+    }
+
 }
 
 class RequestTrackerException extends Exception


### PR DESCRIPTION
Normally this wouldn't be needed, but the way this works now (ie needing user/pass in *every* request) the client might get serialized somewhere for later use. 
Un-serializing with postFields or requestUrl is asking for troubles, so lets avoid that.