### PR TITLE
Fix multiline fields

### DIFF
--- a/RequestTracker.php
+++ b/RequestTracker.php
@@ -539,7 +539,7 @@ class RequestTracker
             elseif(preg_match('/^#/', $line, $matches)) {
                 $responseArray[$line] = '';
             }
-            elseif(preg_match('/^([a-zA-Z0-9]+)' . $delimiter . '\s(.*)$/', $line, $matches)) {
+            elseif(preg_match('/^([a-zA-Z0-9]+|CF\.{[^}]+})' . $delimiter . '\s(.*)$/', $line, $matches)) {
                 $lastkey = $matches[1];
                 $responseArray[$lastkey] = $matches[2];
             }

--- a/RequestTracker.php
+++ b/RequestTracker.php
@@ -543,6 +543,31 @@ class RequestTracker
                 $lastkey = $matches[1];
                 $responseArray[$lastkey] = $matches[2];
             }
+            elseif ((bool) $line && !is_null($lastkey)) {
+                if (preg_match('/\s{4}/i', $line)){
+                    $line = preg_replace('/\s{4}/i', '', $line);
+                }
+                if ($lastkey !== null){
+                        $responseArray[$lastkey] .= PHP_EOL . $line;
+                }
+            }
+            elseif(is_null($lastkey) && preg_match('/\t/', $line)) {
+                foreach ($response as $line) {
+                    if (preg_match('/\t/', $line)) {
+                        if (is_null($lastkey)) {
+                            $lastkey ++;
+                            $fields = explode("\t", $line);
+                        }
+                        elseif (! is_null($lastkey)) {
+                            $result = explode("\t", $line);
+                                foreach($fields as $key => $val) {
+                                    $combined[$val] = $result[$key];
+                                }
+                            $responseArray[] = $combined;
+                        }
+                    }
+                }
+            }            
         }
 
         return $responseArray;


### PR DESCRIPTION
This fix addresses issue #76. It is basically a resubmit of PR #78 made by @oijkn which was closed. However, the master branch is still being affected. If you perform a long format search the results from any multiline filelds only contain the first line of text.